### PR TITLE
Remove unneccesary arguments from pipelineConfig()

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             }
             steps {
                 script {
-                    projectConfig = pipelineConfig('./.sqa/config.yml',null,null,null,'eoscsynergy/jpl-validator:jib-with-jpl')
+                    projectConfig = pipelineConfig()
                     buildStages(projectConfig)
                 }
             }


### PR DESCRIPTION
Last JePL's release/2.1.0 does not require to set all the argments in the pipelineConfig() method.